### PR TITLE
Parameterize SSL redirect after login

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e WEBMIN_INIT_SSL_ENABLED=false` | Enable/Disable Webmin SSL (true/false). If Webmin should be served via SSL or not. Defaults to `true`. |
 | `-e WEBMIN_INIT_REFERERS` | Enable/Disable Webmin SSL (true/false). Sets the allowed referrers to Webmin. Set this to your domain name of the reverse proxy. Example: `mywebmin.example.com`. Defaults to empty (no referrer)|
 | `-e WEBMIN_INIT_REDIRECT_PORT` | The port Webmin is served from. Set this to your reverse proxy port, such as `443`. Defaults to `10000`. |
+| `-e WEBMIN_INIT_REDIRECT_SSL` | Enable/Disable Webmin SSL redirection after login (true/false). Set this to `true` if behind a SSL terminator. Defaults to `false`|
 | `-e BIND_EXTRA_FLAGS` | Default set to -g |
 | `-v /data` | Mount data directory for persistent config  |
 | `-e TZ=Europe/London` | Specify a timezone to use e.g. Europe/London |


### PR DESCRIPTION
This should patch the #18 issue.

It adds a new environment parameter by name `WEBMIN_INIT_REDIRECT_SSL` which is by default off.\
When enabled, it writes the parameters responsible for switching the login response protocol from http to https even when Webmin is not served with its SSL configuration active.